### PR TITLE
Redesign metadata editor and add thumbnail upload

### DIFF
--- a/Video.cs
+++ b/Video.cs
@@ -25,6 +25,7 @@ namespace Airi
         private IReadOnlyList<string> _actors = Array.Empty<string>();
         private IReadOnlyList<string> _tags = Array.Empty<string>();
         private string _thumbnailUri = string.Empty;
+        private string _thumbnailPath = string.Empty;
         private string _description = string.Empty;
 
         public string LibraryPath { get; init; } = string.Empty;
@@ -77,6 +78,12 @@ namespace Airi
         {
             get => _thumbnailUri;
             set => SetField(ref _thumbnailUri, value ?? string.Empty);
+        }
+
+        public string ThumbnailPath
+        {
+            get => _thumbnailPath;
+            set => SetField(ref _thumbnailPath, value ?? string.Empty);
         }
 
         public string Description

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -560,7 +560,7 @@ namespace Airi.ViewModels
 
         private static string BuildSortLabel(string field, bool descending)
         {
-            var arrow = descending ? " ก้" : " ก่";
+            var arrow = descending ? " ยกรฉ" : " ยกรจ";
             return $"{field} {arrow}";
         }
 
@@ -591,6 +591,8 @@ namespace Airi.ViewModels
             var tags = result.Tags ?? Array.Empty<string>();
             var description = result.Description ?? string.Empty;
             var title = string.IsNullOrWhiteSpace(result.Title) ? item.Title : result.Title.Trim();
+            var thumbnailPath = string.IsNullOrWhiteSpace(result.ThumbnailPath) ? item.ThumbnailPath : result.ThumbnailPath;
+            var thumbnailUri = ResolveThumbnailPath(thumbnailPath);
 
             await _dispatcher.InvokeAsync(() =>
             {
@@ -599,6 +601,8 @@ namespace Airi.ViewModels
                 item.Actors = actors;
                 item.Tags = tags;
                 item.Description = description;
+                item.ThumbnailPath = thumbnailPath;
+                item.ThumbnailUri = thumbnailUri;
             });
 
             UpdateLibraryEntry(item.LibraryPath, entry =>
@@ -609,7 +613,8 @@ namespace Airi.ViewModels
                     Date = result.ReleaseDate,
                     Actors = actors,
                     Tags = tags,
-                    Description = description
+                    Description = description,
+                    Thumbnail = thumbnailPath
                 };
                 return entry with { Meta = updatedMeta };
             });
@@ -687,7 +692,8 @@ namespace Airi.ViewModels
                 Actors = entry.Meta.Actors,
                 Tags = entry.Meta.Tags,
                 Description = entry.Meta.Description,
-                ThumbnailUri = ResolveThumbnailPath(entry.Meta.Thumbnail)
+                ThumbnailUri = ResolveThumbnailPath(entry.Meta.Thumbnail),
+                ThumbnailPath = entry.Meta.Thumbnail
             };
 
             item.UpdateFileState(absolutePath, entry.SizeBytes, lastModified, VideoPresenceState.Available);

--- a/ViewModels/MetadataEditorViewModel.cs
+++ b/ViewModels/MetadataEditorViewModel.cs
@@ -1,19 +1,31 @@
 using Airi;
+using Airi.Infrastructure;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Airi.ViewModels
 {
     public sealed class MetadataEditorViewModel : INotifyPropertyChanged
     {
+        private readonly ThumbnailCache _thumbnailCache;
+        private readonly string _thumbnailKey;
+        private readonly string _initialThumbnailPath;
+        private readonly string _initialThumbnailPreviewUri;
+
         private string _title = string.Empty;
         private DateTime? _releaseDate;
         private string _description = string.Empty;
         private string _actorsText = string.Empty;
         private string _tagsText = string.Empty;
+        private string _thumbnailPath = string.Empty;
+        private string _thumbnailPreviewUri = string.Empty;
+        private string _thumbnailDisplayName = string.Empty;
 
         public MetadataEditorViewModel(VideoItem item)
         {
@@ -22,11 +34,23 @@ namespace Airi.ViewModels
                 throw new ArgumentNullException(nameof(item));
             }
 
+            _thumbnailCache = new ThumbnailCache();
+            _thumbnailKey = DetermineThumbnailKey(item);
+
             _title = item.Title;
             _releaseDate = item.ReleaseDate?.ToDateTime(TimeOnly.MinValue);
             _description = item.Description;
             _actorsText = string.Join(Environment.NewLine, item.Actors);
             _tagsText = string.Join(Environment.NewLine, item.Tags);
+
+            _initialThumbnailPath = item.ThumbnailPath ?? string.Empty;
+            _initialThumbnailPreviewUri = string.IsNullOrWhiteSpace(item.ThumbnailUri)
+                ? GetFallbackPreviewUri()
+                : item.ThumbnailUri;
+
+            ThumbnailPath = _initialThumbnailPath;
+            ThumbnailPreviewUri = _initialThumbnailPreviewUri;
+            ThumbnailDisplayName = BuildDisplayName(_initialThumbnailPath);
         }
 
         public string Title
@@ -59,7 +83,57 @@ namespace Airi.ViewModels
             set => SetProperty(ref _tagsText, value ?? string.Empty);
         }
 
+        public string ThumbnailPath
+        {
+            get => _thumbnailPath;
+            private set => SetProperty(ref _thumbnailPath, value ?? string.Empty);
+        }
+
+        public string ThumbnailPreviewUri
+        {
+            get => _thumbnailPreviewUri;
+            private set => SetProperty(ref _thumbnailPreviewUri, value ?? string.Empty);
+        }
+
+        public string ThumbnailDisplayName
+        {
+            get => _thumbnailDisplayName;
+            private set => SetProperty(ref _thumbnailDisplayName, value ?? string.Empty);
+        }
+
         public event PropertyChangedEventHandler? PropertyChanged;
+
+        public async Task<bool> UpdateThumbnailFromFileAsync(string filePath, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+            {
+                return false;
+            }
+
+            var bytes = await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false);
+            if (bytes.Length == 0)
+            {
+                return false;
+            }
+
+            var extension = Path.GetExtension(filePath);
+            var relativePath = await _thumbnailCache.SaveAsync(bytes, extension, _thumbnailKey, cancellationToken).ConfigureAwait(false);
+            var absolutePath = LibraryPathHelper.ResolveToAbsolute(relativePath);
+            var previewUri = File.Exists(absolutePath) ? new Uri(absolutePath).AbsoluteUri : ThumbnailPreviewUri;
+
+            ThumbnailPath = relativePath;
+            ThumbnailPreviewUri = previewUri;
+            ThumbnailDisplayName = Path.GetFileName(filePath);
+
+            return true;
+        }
+
+        public void ResetThumbnail()
+        {
+            ThumbnailPath = _initialThumbnailPath;
+            ThumbnailPreviewUri = _initialThumbnailPreviewUri;
+            ThumbnailDisplayName = BuildDisplayName(_initialThumbnailPath);
+        }
 
         public bool TryBuildResult(out MetadataEditResult result, out string? error)
         {
@@ -68,7 +142,7 @@ namespace Airi.ViewModels
             var title = (Title ?? string.Empty).Trim();
             if (string.IsNullOrWhiteSpace(title))
             {
-                error = "¡¶∏Ò¿ª ¿‘∑¬«ÿ¡÷ººø‰.";
+                error = "Ï†úÎ™©ÏùÑ ÏûÖÎ†•Ìï¥Ï£ºÏÑ∏Ïöî.";
                 result = default;
                 return false;
             }
@@ -83,7 +157,7 @@ namespace Airi.ViewModels
             var actors = SplitList(ActorsText);
             var tags = SplitList(TagsText);
 
-            result = new MetadataEditResult(title, releaseDate, actors, tags, description);
+            result = new MetadataEditResult(title, releaseDate, actors, tags, description, ThumbnailPath);
             return true;
         }
 
@@ -95,13 +169,37 @@ namespace Airi.ViewModels
             }
 
             var tokens = source
-                .Split(new[] { '\r', '\n', ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { '', '
+', ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(token => token.Trim())
                 .Where(token => token.Length > 0)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
 
             return tokens.Length == 0 ? Array.Empty<string>() : tokens;
+        }
+
+        private static string DetermineThumbnailKey(VideoItem item)
+        {
+            var normalized = LibraryPathHelper.NormalizeCode(item.Title);
+            if (!string.IsNullOrWhiteSpace(normalized))
+            {
+                return normalized;
+            }
+
+            var fileName = Path.GetFileNameWithoutExtension(item.LibraryPath);
+            return string.IsNullOrWhiteSpace(fileName) ? "thumb" : fileName;
+        }
+
+        private static string BuildDisplayName(string path)
+        {
+            return string.IsNullOrWhiteSpace(path) ? "Í∏∞Î≥∏ Ïù¥ÎØ∏ÏßÄ ÏÇ¨Ïö© Ï§ë" : Path.GetFileName(path);
+        }
+
+        private static string GetFallbackPreviewUri()
+        {
+            var fallbackPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "resources", "noimage.jpg");
+            return File.Exists(fallbackPath) ? new Uri(fallbackPath).AbsoluteUri : string.Empty;
         }
 
         private void SetProperty<T>(ref T field, T value, [CallerMemberName] string propertyName = "")
@@ -119,6 +217,6 @@ namespace Airi.ViewModels
         DateOnly? ReleaseDate,
         IReadOnlyList<string> Actors,
         IReadOnlyList<string> Tags,
-        string Description);
+        string Description,
+        string ThumbnailPath);
 }
-

--- a/Views/MetadataEditorWindow.xaml
+++ b/Views/MetadataEditorWindow.xaml
@@ -1,58 +1,204 @@
-﻿<Window x:Class="Airi.Views.MetadataEditorWindow"
+<Window x:Class="Airi.Views.MetadataEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="메타데이터 편집" Width="520" WindowStartupLocation="CenterOwner"
-        ResizeMode="NoResize" Background="#1E1F29" Foreground="White"
+        Title="메타데이터 편집" Width="720" MinHeight="540"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize" Background="#0F111C" Foreground="#E8ECF9"
         WindowStyle="SingleBorderWindow" ShowInTaskbar="False">
-    <Border Padding="20" Background="#1E1F29">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
+    <Window.Resources>
+        <Style x:Key="HeadingTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="22"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="#FFFFFF"/>
+        </Style>
+        <Style x:Key="SubtitleTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Foreground" Value="#96A1C2"/>
+        </Style>
+        <Style x:Key="FieldLabelStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="#C7CEE4"/>
+            <Setter Property="Margin" Value="0,0,0,6"/>
+        </Style>
+        <Style x:Key="CardBorderStyle" TargetType="Border">
+            <Setter Property="CornerRadius" Value="18"/>
+            <Setter Property="Background" Value="#151828"/>
+            <Setter Property="Padding" Value="26"/>
+        </Style>
+        <Style x:Key="InputBoxStyle" TargetType="TextBox">
+            <Setter Property="Background" Value="#1E2234"/>
+            <Setter Property="BorderBrush" Value="#2E3350"/>
+            <Setter Property="Foreground" Value="#FFFFFF"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="10"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style x:Key="DatePickerStyle" TargetType="DatePicker">
+            <Setter Property="Background" Value="#1E2234"/>
+            <Setter Property="BorderBrush" Value="#2E3350"/>
+            <Setter Property="Foreground" Value="#FFFFFF"/>
+            <Setter Property="Padding" Value="8"/>
+        </Style>
+        <Style x:Key="PrimaryButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="#3B82F6"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Padding" Value="10 8"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="SnapsToDevicePixels" Value="True"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}" CornerRadius="12">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="#4D8FFF"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter Property="Background" Value="#2F6BD8"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Style x:Key="GhostButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderBrush" Value="#39405C"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Foreground" Value="#C7CEE4"/>
+            <Setter Property="Padding" Value="10 8"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="12">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="BorderBrush" Value="#4D5675"/>
+                                <Setter Property="Foreground" Value="#FFFFFF"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
 
-            <StackPanel Margin="0,0,0,16">
-                <TextBlock Text="메타데이터 편집" FontSize="20" FontWeight="SemiBold" Margin="0,0,0,12"/>
-                <TextBlock Text="필드를 수정한 후 저장을 누르세요." FontSize="12" Foreground="#AEB8CC"/>
-            </StackPanel>
+    <Grid Background="#0F111C">
+        <Border Style="{StaticResource CardBorderStyle}" Margin="24">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
 
-            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
-                <StackPanel Orientation="Vertical" Margin="0,0,0,8">
-                    <StackPanel Margin="0,0,0,12">
-                        <TextBlock Text="제목" FontWeight="SemiBold" Margin="0,0,0,4"/>
-                        <TextBox Text="{Binding Title, UpdateSourceTrigger=PropertyChanged}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="0,0,0,12">
-                        <TextBlock Text="출시일" FontWeight="SemiBold" Margin="0,0,0,4"/>
-                        <DatePicker SelectedDate="{Binding ReleaseDate}" DisplayDateStart="1900-01-01"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="0,0,0,12">
-                        <TextBlock Text="내용" FontWeight="SemiBold" Margin="0,0,0,4"/>
-                        <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}" AcceptsReturn="True" TextWrapping="Wrap" Height="120"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="0,0,0,12">
-                        <TextBlock Text="배우 (줄바꿈 또는 콤마로 구분)" FontWeight="SemiBold" Margin="0,0,0,4"/>
-                        <TextBox Text="{Binding ActorsText, UpdateSourceTrigger=PropertyChanged}" AcceptsReturn="True" TextWrapping="Wrap" Height="80"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="0,0,0,12">
-                        <TextBlock Text="태그 (줄바꿈 또는 콤마로 구분)" FontWeight="SemiBold" Margin="0,0,0,4"/>
-                        <TextBox Text="{Binding TagsText, UpdateSourceTrigger=PropertyChanged}" AcceptsReturn="True" TextWrapping="Wrap" Height="80"/>
-                    </StackPanel>
+                <StackPanel Orientation="Vertical" Margin="0,0,0,18">
+                    <TextBlock Text="메타데이터 편집" Style="{StaticResource HeadingTextStyle}"/>
+                    <TextBlock Text="필드를 수정한 후 저장을 누르세요." Style="{StaticResource SubtitleTextStyle}"
+                               Margin="0,6,0,0"/>
                 </StackPanel>
-            </ScrollViewer>
 
-            <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
-                <Button Content="취소" Width="90" Margin="0,0,8,0" Click="OnCancelClick"/>
-                <Button Content="저장" Width="90" IsDefault="True" Click="OnSaveClick" Background="#3B82F6"/>
-            </StackPanel>
-        </Grid>
-    </Border>
+                <Grid Grid.Row="1" Margin="0" >
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="260"/>
+                        <ColumnDefinition Width="24"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Border Background="#1A1E2F" CornerRadius="16" Padding="16" Grid.Column="0" ClipToBounds="True">
+                        <Grid>
+                            <Image Source="{Binding ThumbnailPreviewUri}" Stretch="UniformToFill"/>
+                            <Border Background="#990F111C" CornerRadius="12" VerticalAlignment="Top"
+                                    HorizontalAlignment="Left" Padding="10 6">
+                                <TextBlock Text="커버 이미지" FontWeight="SemiBold" Foreground="#F4F6FF" FontSize="12"/>
+                            </Border>
+                        </Grid>
+                    </Border>
+
+                    <StackPanel Grid.Column="2" Orientation="Vertical" Margin="0" >
+                        <Border Background="#1A1E2F" CornerRadius="14" Padding="16">
+                            <StackPanel>
+                                <TextBlock Text="썸네일 이미지" Style="{StaticResource FieldLabelStyle}"/>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,4,0,0">
+                                    <Button Content="파일 선택" Style="{StaticResource PrimaryButtonStyle}"
+                                            Width="100" Click="OnSelectThumbnailClick"/>
+                                    <Button Content="초기화" Style="{StaticResource GhostButtonStyle}"
+                                            Width="88" Margin="8,0,0,0" Click="OnResetThumbnailClick"/>
+                                    <TextBlock Text="{Binding ThumbnailDisplayName}" Foreground="#96A1C2"
+                                               VerticalAlignment="Center" Margin="12,0,0,0"/>
+                                </StackPanel>
+                                <TextBlock Text="선택한 이미지는 캐시에 저장되어 메타데이터와 연결됩니다."
+                                           Style="{StaticResource SubtitleTextStyle}" Margin="0,8,0,0"/>
+                            </StackPanel>
+                        </Border>
+
+                        <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,18,0,0">
+                            <StackPanel Orientation="Vertical" Margin="0">
+                                <StackPanel Margin="0,0,0,16">
+                                    <TextBlock Text="제목" Style="{StaticResource FieldLabelStyle}"/>
+                                    <TextBox Text="{Binding Title, UpdateSourceTrigger=PropertyChanged}"
+                                             Style="{StaticResource InputBoxStyle}"/>
+                                </StackPanel>
+
+                                <StackPanel Margin="0,0,0,16">
+                                    <TextBlock Text="출시일" Style="{StaticResource FieldLabelStyle}"/>
+                                    <DatePicker SelectedDate="{Binding ReleaseDate}" DisplayDateStart="1900-01-01"
+                                                Style="{StaticResource DatePickerStyle}"/>
+                                </StackPanel>
+
+                                <StackPanel Margin="0,0,0,16">
+                                    <TextBlock Text="내용" Style="{StaticResource FieldLabelStyle}"/>
+                                    <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
+                                             Style="{StaticResource InputBoxStyle}" AcceptsReturn="True"
+                                             TextWrapping="Wrap" Height="120"/>
+                                </StackPanel>
+
+                                <Grid Margin="0,0,0,16">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="16"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <StackPanel Grid.Column="0">
+                                        <TextBlock Text="배우" Style="{StaticResource FieldLabelStyle}"/>
+                                        <TextBox Text="{Binding ActorsText, UpdateSourceTrigger=PropertyChanged}"
+                                                 Style="{StaticResource InputBoxStyle}" AcceptsReturn="True"
+                                                 TextWrapping="Wrap" Height="90"/>
+                                        <TextBlock Text="줄바꿈 또는 콤마로 구분하세요."
+                                                   Style="{StaticResource SubtitleTextStyle}" Margin="0,6,0,0"/>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Column="2">
+                                        <TextBlock Text="태그" Style="{StaticResource FieldLabelStyle}"/>
+                                        <TextBox Text="{Binding TagsText, UpdateSourceTrigger=PropertyChanged}"
+                                                 Style="{StaticResource InputBoxStyle}" AcceptsReturn="True"
+                                                 TextWrapping="Wrap" Height="90"/>
+                                        <TextBlock Text="줄바꿈 또는 콤마로 구분하세요."
+                                                   Style="{StaticResource SubtitleTextStyle}" Margin="0,6,0,0"/>
+                                    </StackPanel>
+                                </Grid>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </StackPanel>
+                </Grid>
+
+                <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,24,0,0">
+                    <Button Content="취소" Width="116" Style="{StaticResource GhostButtonStyle}"
+                            Click="OnCancelClick"/>
+                    <Button Content="저장" Width="116" Style="{StaticResource PrimaryButtonStyle}"
+                            Margin="12,0,0,0" IsDefault="True" Click="OnSaveClick"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+    </Grid>
 </Window>
-
-
-

--- a/Views/MetadataEditorWindow.xaml.cs
+++ b/Views/MetadataEditorWindow.xaml.cs
@@ -1,6 +1,8 @@
 using Airi;
+using System;
 using System.Windows;
 using Airi.ViewModels;
+using Microsoft.Win32;
 
 namespace Airi.Views
 {
@@ -14,6 +16,44 @@ namespace Airi.Views
 
         public MetadataEditResult? Result { get; private set; }
 
+        private async void OnSelectThumbnailClick(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not MetadataEditorViewModel vm)
+            {
+                return;
+            }
+
+            var dialog = new OpenFileDialog
+            {
+                Title = "썸네일 이미지 선택",
+                Filter = "이미지 파일 (*.jpg;*.jpeg;*.png;*.webp;*.bmp)|*.jpg;*.jpeg;*.png;*.webp;*.bmp|모든 파일 (*.*)|*.*"
+            };
+
+            if (dialog.ShowDialog(this) == true)
+            {
+                try
+                {
+                    var updated = await vm.UpdateThumbnailFromFileAsync(dialog.FileName);
+                    if (!updated)
+                    {
+                        MessageBox.Show(this, "이미지 파일을 불러오지 못했습니다.", "경고", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(this, $"썸네일을 업데이트하는 중 오류가 발생했습니다.\n{ex.Message}", "오류", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+        }
+
+        private void OnResetThumbnailClick(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is MetadataEditorViewModel vm)
+            {
+                vm.ResetThumbnail();
+            }
+        }
+
         private void OnSaveClick(object sender, RoutedEventArgs e)
         {
             if (DataContext is not MetadataEditorViewModel vm)
@@ -24,7 +64,7 @@ namespace Airi.Views
 
             if (!vm.TryBuildResult(out var result, out var error))
             {
-                MessageBox.Show(this, error ?? "�Է� ���� Ȯ�����ּ���.", "��ȿ�� �˻�", MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBox.Show(this, error ?? "입력을 확인해주세요.", "입력 오류", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 
@@ -38,4 +78,3 @@ namespace Airi.Views
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- redesign the metadata editor dialog with a refreshed dark layout matching the provided inspiration
- add thumbnail selection/reset controls that preview the chosen image and persist it in the cache for metadata usage
- extend metadata handling so edited thumbnails are stored with video items and saved back to the library

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c8528fd88326a0fecf3c4a62ed26